### PR TITLE
Add proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-*
 *.gem
 .bundle
 Gemfile.lock

--- a/README.rdoc
+++ b/README.rdoc
@@ -34,14 +34,15 @@ The RPC method names available to you are exactly the same as those listed on th
 (again, that's {https://en.bitcoin.it/wiki/Original_Startcoin_client/API_Calls_list}[https://en.bitcoin.it/wiki/Original_Startcoin_client/API_Calls_list]). Some aliases
 have been added to make them more "ruby-ish," but none of the original names have been changed.
 
-== Host, Port and SSL
+== Host, Port, SSL, Proxy
 
-Here are several examples of how you can change the host information:
+Here are several examples of how you can change the host and proxy information:
 
-  StartcoinClient('username', 'password', :host => 'example.com', :port => 38332, :ssl => true)
+  StartcoinClient('username', 'password', :host => 'example.com', :port => 38332, :ssl => true, :proxy => 'http://someproxy.com')
 
   client = StartcoinClient::Client.new('username', 'password', :host => 'example.com')
   client.port = 38332
+  client.proxy = 'http://someproxy.com'
   client.ssl = true
   client.ssl?
   # => true

--- a/lib/startcoin_client/api.rb
+++ b/lib/startcoin_client/api.rb
@@ -8,17 +8,20 @@ class StartcoinClient::API
   def port; options[:port]; end
   def ssl;  options[:ssl];  end
   def ssl?; options[:ssl];  end
+  def proxy; options[:proxy]; end
   def user=(a); options[:user] = a; end
   def pass=(a); options[:pass] = a; end
   def host=(a); options[:host] = a; end
   def port=(a); options[:port] = a; end
   def ssl=(a);  options[:ssl]  = a; end
+  def proxy=(a); options[:proxy] = a; end
 
   def initialize(options = {})
     @options = {
       :host => 'localhost',
       :port => 8332,
-      :ssl  => false
+      :ssl  => false,
+      :proxy => nil
     }.merge(options)
   end
 

--- a/lib/startcoin_client/client.rb
+++ b/lib/startcoin_client/client.rb
@@ -5,12 +5,14 @@ class StartcoinClient::Client
   def host; api.host; end
   def port; api.port; end
   def ssl;  api.ssl;  end
+  def proxy; api.proxy; end
   def ssl?; api.ssl?; end
   def user=(a); api.user = a; end
   def pass=(a); api.pass = a; end
   def host=(a); api.host = a; end
   def port=(a); api.port = a; end
   def ssl=(a);  api.ssl  = a; end
+  def proxy=(a); api.proxy = a; end
 
   def options
     api.options

--- a/lib/startcoin_client/dsl.rb
+++ b/lib/startcoin_client/dsl.rb
@@ -27,6 +27,10 @@ module StartcoinClient::DSL
     bitcoin.ssl = value
   end
 
+  def proxy=(value)
+    bitcoin.proxy = value
+  end
+
   def username(value = nil)
     value ? bitcoin.user = value : bitcoin.user
   end
@@ -45,6 +49,10 @@ module StartcoinClient::DSL
 
   def ssl(value = nil)
     value.nil? ? bitcoin.ssl : bitcoin.ssl = value
+  end
+
+  def proxy(value = nil)
+    value.nil? ? bitcoin.proxy : bitcoin.proxy = value
   end
 
   def ssl?

--- a/lib/startcoin_client/version.rb
+++ b/lib/startcoin_client/version.rb
@@ -2,7 +2,7 @@ module StartcoinClient
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 3
+    PATCH = 4
     REL = nil
 
     STRING = REL ? [MAJOR, MINOR, PATCH, REL].join('.') : [MAJOR, MINOR, PATCH].join('.')

--- a/spec/lib/startcoin_client/api_spec.rb
+++ b/spec/lib/startcoin_client/api_spec.rb
@@ -3,16 +3,23 @@ require 'spec_helper'
 describe StartcoinClient::API do
   subject { StartcoinClient::API.new(:user => $user, :pass => $pass) }
 
-  it "should have default host, port, ssl" do
+  it "should have default host, port, ssl, proxy" do
     subject.host.should == 'localhost'
     subject.port.should == 8332
     subject.ssl?.should be_false
+    subject.proxy.should be_nil
   end
 
-  it "should accept host, port, ssl options" do
-    req = StartcoinClient::API.new(:user => $user, :pass => $pass, :host => 'example.com', :port => 1234, :ssl => true)
+  it "should accept host, port, ssl, proxy options" do
+    req = StartcoinClient::API.new(:user => $user,
+                                   :pass => $pass,
+                                   :host => 'example.com',
+                                   :port => 1234,
+                                   :ssl => true,
+                                   :proxy => 'proxy.com')
     req.host.should == 'example.com'
     req.port.should == 1234
+    req.proxy.should == 'proxy.com'
     req.ssl?.should be_true
   end
 
@@ -23,6 +30,7 @@ describe StartcoinClient::API do
       :host => 'localhost',
       :port => 8332,
       :ssl => false,
+      :proxy => nil
     }
   end
 end

--- a/spec/lib/startcoin_client/client_spec.rb
+++ b/spec/lib/startcoin_client/client_spec.rb
@@ -8,6 +8,7 @@ describe StartcoinClient::Client do
     subject.pass.should == $pass
     subject.host.should == 'localhost'
     subject.port.should == 8332
+    subject.proxy.should be_nil
     subject.should_not be_ssl
   end
 

--- a/startcoin-client.gemspec
+++ b/startcoin-client.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec",   '~> 2.6'
   s.add_development_dependency "fakeweb", '~> 1.3'
   s.add_development_dependency "coveralls"
-  s.add_runtime_dependency "rest-client"
+  s.add_runtime_dependency "rest-client", '~> 2.0'
 end


### PR DESCRIPTION
## Description
Hey! In this PR I allowed user to specify `proxy` option when connecting to the RPC API. The default proxy is set to `nil` and you can override it by an option when creating `Client` object. It will be passed to the `RPC` class that makes the requests. `proxy` has been also added to the DSL extension. Added few lines in README about how to set proxy. Set `rest-client` version to at least 2.0, as using the feature that is not available in 1.x.

## Motivation and Context
Need to connect to the API via proxy (that allows to set a static IP f.e.).

## How Has This Been Tested?
`./spec/lib/startcoin_client/api_spec.rb`
`./spec/lib/startcoin_client/client_spec.rb`
