### PR TITLE
Feature/add verify ssl option

### DIFF
--- a/lib/startcoin_client/api.rb
+++ b/lib/startcoin_client/api.rb
@@ -21,7 +21,8 @@ class StartcoinClient::API
       :host => 'localhost',
       :port => 8332,
       :ssl  => false,
-      :proxy => nil
+      :proxy => nil,
+      :verify_ssl => true
     }.merge(options)
   end
 

--- a/lib/startcoin_client/rpc.rb
+++ b/lib/startcoin_client/rpc.rb
@@ -5,6 +5,7 @@ class StartcoinClient::RPC
     @user, @pass = options[:user], options[:pass]
     @host, @port = options[:host], options[:port]
     @ssl, @proxy = options[:ssl], options[:proxy]
+    @verify_ssl  = options[:verify_ssl]
   end
 
   def credentials
@@ -32,11 +33,13 @@ class StartcoinClient::RPC
                                 url: service_url,
                                 payload: request.to_post_data,
                                 proxy: @proxy,
+                                verify_ssl: false,
                                 headers: { content_type: :json },
                                 &process_response)
   end
 
   private
+
   def symbolize_keys(hash)
     case hash
     when Hash

--- a/spec/lib/startcoin_client/api_spec.rb
+++ b/spec/lib/startcoin_client/api_spec.rb
@@ -30,7 +30,8 @@ describe StartcoinClient::API do
       :host => 'localhost',
       :port => 8332,
       :ssl => false,
-      :proxy => nil
+      :proxy => nil,
+      :verify_ssl => true
     }
   end
 end


### PR DESCRIPTION
Add ability to specify `verify_ssl` RestClient option. Useful when you want to disable it.